### PR TITLE
Add CANA Holdings California Carbon Credits to bridged_tokens/mainnet.json

### DIFF
--- a/bridged_tokens/mainnet.json
+++ b/bridged_tokens/mainnet.json
@@ -1218,5 +1218,15 @@
         "l1_bridge_address": "0x7a095101eF5c7a66056f801335F8605d3b2452a5",
         "l2_bridge_address": "0x0639069b8c2daef5a245fc82b7be76f44dad088f078a99c17eb5f157af7463cc",
         "l2_token_address": "0x04e4fb1a9ca7e84bae609b9dc0078ad7719e49187ae7e425bb47d131710eddac"
+    },
+    {
+        "id": "cana",
+        "name": "CANA Holdings California Carbon Credits",
+        "symbol": "CANA",
+        "decimals": 18,
+        "l1_token_address": "0x01995A697752266d8E748738aAa3F06464B8350B",
+        "l1_bridge_address": "0xF5b6Ee2CAEb6769659f6C091D209DfdCaF3F69Eb",
+        "l2_bridge_address": "0x0616757a151c21f9be8775098d591c2807316d992bbc3bb1a5c1821630589256",
+        "l2_token_address": "0x023B5A53775fAd266C8a296c7C595C46072c4Fc0cCF557d63afBcC11C2D915C1"
     }
 ]


### PR DESCRIPTION
  # Add CANA Holdings California Carbon Credits to bridged_tokens/mainnet.json

  ## Summary

  Adds CANA Holdings California Carbon Credits (CANA) to the mainnet bridged tokens list.

  CANA gives DeFi users direct exposure to California Carbon Allowances—a ~$78B regulated commodity—with a CPI+5% rising price floor and full DeFi 
  composability.

  ## Change

  Appends the following entry:

  ```json
  {
    "id": "cana",
    "name": "CANA Holdings California Carbon Credits",
    "symbol": "CANA",
    "decimals": 18,
    "l1_token_address": "0x01995A697752266d8E748738aAa3F06464B8350B",
    "l1_bridge_address": "0xF5b6Ee2CAEb6769659f6C091D209DfdCaF3F69Eb",
    "l2_bridge_address": "0x0616757a151c21f9be8775098d591c2807316d992bbc3bb1a5c1821630589256",
    "l2_token_address": "0x023B5A53775fAd266C8a296c7C595C46072c4Fc0cCF557d63afBcC11C2D915C1"
  }
```

  Notes for Reviewers

  - decimals: 18
  - Address formats: L1 are EVM checksummed; L2 are 32-byte felts with 0x prefix.
  - Included explorer links below for quick verification.

  Verification Checklist

  - Etherscan shows symbol = CANA, decimals = 18 for the L1 token
  - L1 bridge / L2 bridge route is correct for this token
  - Starkscan/Voyager contract pages resolve for both L2 addresses

  Links

  L1 (Ethereum)

  - Token: https://etherscan.io/token/0x01995a697752266d8e748738aaa3f06464b8350b
  - Bridge: https://etherscan.io/address/0xf5b6ee2caeb6769659f6c091d209dfdcaf3f69eb

  L2 (Starknet)

  - Bridge (Starkscan): https://starkscan.co/contract/0x0616757a151c21f9be8775098d591c2807316d992bbc3bb1a5c1821630589256
  - Bridge (Voyager): https://voyager.online/contract/0x0616757a151c21f9be8775098d591c2807316d992bbc3bb1a5c1821630589256
  - Token (Starkscan): https://starkscan.co/contract/0x023b5a53775fad266c8a296c7c595c46072c4fc0ccf557d63afbcc11c2d915c1
  - Token (Voyager): https://voyager.online/contract/0x023b5a53775fad266c8a296c7c595c46072c4fc0ccf557d63afbcc11c2d915c1

  Project & Asset References

  - App: https://maseer.finance/
  - Dashboard: https://cana.maseer.finance/
  - CoinGecko: https://www.coingecko.com/en/coins/cana-holdings-california-carbon-credits